### PR TITLE
feat: add video description as a chapter source

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -1,5 +1,7 @@
 import * as youtubei from './youtubei.js'
 
+const MIN_NUM_CHAPTERS = 2
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === 'fetchChapters') {
         fetchChapters(request.videoId)
@@ -34,9 +36,7 @@ function fetchChaptersFromDescription(videoResponse) {
     }
 
     const tsContexts = getTimestampContexts(description)
-    const minNumChapters = 2
-
-    return tsContexts.length >= minNumChapters ? tsContexts : []
+    return tsContexts.length >= MIN_NUM_CHAPTERS ? tsContexts : []
 }
 
 async function fetchChaptersFromComments(videoResponse) {
@@ -47,9 +47,8 @@ async function fetchChaptersFromComments(videoResponse) {
     }
 
     const tsContexts = getTimestampContexts(pinnedComment.text)
-    const minNumChapters = 2
 
-    return tsContexts.length >= minNumChapters ? tsContexts : []
+    return tsContexts.length >= MIN_NUM_CHAPTERS ? tsContexts : []
 }
 
 

--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -18,8 +18,25 @@ async function fetchChapters(videoId) {
         return chapters
     }
 
+    chapters = fetchChaptersFromDescription(videoResponse)
+    if (chapters.length) {
+        return chapters
+    }
+
     chapters = await fetchChaptersFromComments(videoResponse)
-    return chapters    
+    return chapters
+}
+
+function fetchChaptersFromDescription(videoResponse) {
+    const description = youtubei.descriptionFromVideoResponse(videoResponse)
+    if (!description) {
+        return []
+    }
+
+    const tsContexts = getTimestampContexts(description)
+    const minNumChapters = 2
+
+    return tsContexts.length >= minNumChapters ? tsContexts : []
 }
 
 async function fetchChaptersFromComments(videoResponse) {

--- a/extension/background/youtubei.js
+++ b/extension/background/youtubei.js
@@ -53,6 +53,24 @@ function macroMarkersListItemRendererToChapter(renderer) {
     }
 }
 
+export function descriptionFromVideoResponse(videoResponse) {
+    try {
+        const playerResponse = Array.isArray(videoResponse)
+            ? videoResponse.find(e => e.playerResponse)?.playerResponse
+            : videoResponse.playerResponse
+        if (!playerResponse) {
+            return ''
+        }
+        const videoDetails = typeof playerResponse === 'string'
+            ? JSON.parse(playerResponse).videoDetails
+            : playerResponse.videoDetails
+        return videoDetails?.shortDescription || ''
+    } catch (e) {
+        console.error('Failed to extract description from video response', e)
+        return ''
+    }
+}
+
 export async function fetchVideo(videoId) {
     const response = await fetch(`https://www.youtube.com/watch?v=${videoId}&pbj=1`, {
         credentials: "omit",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "YouTube Chapters In Player",
     "description": "Shows YouTube chapters right in the player",
-    "version": "0.3.5",
+    "version": "0.4.0",
 
     "permissions": [
         "webRequest",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "YouTube Chapters In Player",
     "description": "Shows YouTube chapters right in the player",
-    "version": "0.4.0",
+    "version": "0.3.5",
 
     "permissions": [
         "webRequest",


### PR DESCRIPTION
## Summary
Add video description timestamps as a new chapter source, falling back between YouTube's native chapters and pinned comment chapters.

## Updated fallback chain
1. **Native chapters** — from YouTube's engagement panel metadata (existing)
2. **Description timestamps** — parsed from the video description (new)
3. **Pinned comment timestamps** — parsed from the pinned comment (existing)

## Why
Channels without sufficient watch history or subscriber count don't get YouTube's native chapter markers, even when the video description contains properly formatted timestamps (e.g. `0:00 Introduction`, `1:23 Topic Name`). This change extracts those timestamps from the description and displays them as chapters in the player.

## Notes
- No new permissions or API calls required — the description is already present in the response from `fetchVideo()`.
- No changes to the content script or UI — chapters from all three sources use the same `{ title, timestamp, time }` format.